### PR TITLE
Restore jQuery objects if they're undefined

### DIFF
--- a/gipsy/dashboard/templates/admin/base.html
+++ b/gipsy/dashboard/templates/admin/base.html
@@ -153,6 +153,14 @@
     <script src="{{ STATIC_URL }}gipsy_dashboard/javascripts/bootstrap.js"></script>
     <script src="{{ STATIC_URL }}gipsy_dashboard/javascripts/plugins.js"></script>
     <script src="{{ STATIC_URL }}gipsy_dashboard/javascripts/main.js"></script>
-    <script>var gipsy = {jQuery: jQuery.noConflict(true)};</script>
+    <script>
+        var gipsy = {jQuery: jQuery.noConflict(true)};
+        if (typeof(window.$) === 'undefined') {
+            window.$ = gipsy.jQuery;
+        };
+        if (typeof(window.jQuery) === 'undefined') {
+            window.jQuery = gipsy.jQuery;
+        };
+    </script>
 </body>
 </html>


### PR DESCRIPTION
Hi! This commit fixes js conflicts with django-mptt-admin and probably other packages. Under certain circumstances, using `jQuery.noConflict(true)` results in no jQuery objects in global namespace. Callbacks deferred until DOM finishes loading won't work then, since jQuery objects are `undefined`. This fix checkes if there are jQuery objects in global namespace, and if not - restores them. It has no impact on behaviour if other jQuery objects are already loaded.
