### PR TITLE
Fix wrong urls in dashboard when deploying multiple site instances

### DIFF
--- a/gipsy/dashboard/admin.py
+++ b/gipsy/dashboard/admin.py
@@ -54,6 +54,7 @@ class GipsyAdminSite(AdminSite):
         Displays the dashboard on the main page and triggers widget
         from the settings.GIPSY_DASHBOARD constant.
         """
+        request.current_app = self.name
         context = dict(
             dashboard=self.init_dashboard_class()(request),
         )


### PR DESCRIPTION
Hi Guillaume,

Default Django admin app can be deployed in multiple instances. There are valid use cases for that and it's a documented, supported behaviour; see https://docs.djangoproject.com/en/1.8/ref/contrib/admin/#multiple-admin-sites-in-the-same-urlconf for details.

To enable proper resolution of namespace urls, `request.current_app` property must be set to application's instance name. Django admin app does it all over it's methods, but currently Gipsy's `dashboard()`method doesn't do that, resulting in namespace urls always resolving to last deployed instance. This commit fixes the issue for Django 1.8.
